### PR TITLE
fix "trailing semicolon in macro used in expression position" warning

### DIFF
--- a/src/proxy/socks5.rs
+++ b/src/proxy/socks5.rs
@@ -50,7 +50,7 @@ where
 
 macro_rules! err {
     ($msg:expr) => {
-        return Err(io::Error::new(ErrorKind::Other, $msg));
+        return Err(io::Error::new(ErrorKind::Other, $msg))
     };
 }
 


### PR DESCRIPTION
warned by rust 1.56.0
```
warning: trailing semicolon in macro used in expression position
  --> src/proxy/socks5.rs:53:52
   |
53 |         Err(io::Error::new(ErrorKind::Other, $msg));
   |                                                    ^
...
83 |         [0x05, 0xff] => err!("auth required by socks server"),
   |                         ------------------------------------- in this macro invocation
   |
   = note: `#[warn(semicolon_in_expressions_from_macros)]` on by default
   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
   = note: for more information, see issue #79813 <https://github.com/rust-lang/rust/issues/79813>
   = note: this warning originates in the macro `err` (in Nightly builds, run with -Z macro-backtrace for more info)
```