### PR TITLE
Add support target release `x86_64-unknown-linux-musl`

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -49,6 +49,11 @@ jobs:
         with:
           use-cross: true
           command: build
+          args: --target x86_64-unknown-linux-musl --release
+      - uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: build
           args: --target armv7-unknown-linux-gnueabihf --release
       - uses: actions-rs/cargo@v1
         with:
@@ -60,6 +65,7 @@ jobs:
           use-cross: true
           command: build
           args: --target mips-unknown-linux-musl --release
+      - run: xz -kfS "_${GITHUB_REF#*/v}_linux_x86_64_musl.bin.xz" target/x86_64-unknown-linux-musl/release/moproxy
       - run: xz -kfS "_${GITHUB_REF#*/v}_linux_armv7_gnueabihf.bin.xz" target/armv7-unknown-linux-gnueabihf/release/moproxy 
       - run: xz -kfS "_${GITHUB_REF#*/v}_linux_aarch64_android.bin.xz" target/aarch64-linux-android/release/moproxy 
       - run: xz -kfS "_${GITHUB_REF#*/v}_linux_mips_musl.bin.xz" target/mips-unknown-linux-musl/release/moproxy


### PR DESCRIPTION
By default rust build `moproxy` using `glibc`. This target is useful for alpine based docker container for instance to directly download `moproxy` without having to build it, alpine use `musl` by default.