### PR TITLE
Support domain name resolution for proxy address from the proxy list.

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -2,7 +2,7 @@ use anyhow::{anyhow, bail, Context};
 use futures_util::{stream, StreamExt};
 use ini::Ini;
 use parking_lot::RwLock;
-use std::{collections::HashSet, io, net::SocketAddr, path::PathBuf, sync::Arc, time::Duration};
+use std::{collections::HashSet, io, net::SocketAddr, net::ToSocketAddrs, path::PathBuf, sync::Arc, time::Duration};
 use tokio::net::{TcpListener, TcpStream};
 use tracing::{error, info, instrument, warn};
 
@@ -286,8 +286,9 @@ impl ServerListConfig {
                 let addr: SocketAddr = props
                     .get("address")
                     .ok_or(anyhow!("address not specified"))?
-                    .parse()
-                    .context("not a valid socket address")?;
+                    .to_socket_addrs()
+                    .context("not a valid socket address")?
+                    .next().unwrap();
                 let base = props
                     .get("score base")
                     .parse()


### PR DESCRIPTION
Add support for domain name resolution for proxy addresses passed in the proxy list. In some use-cases you need to pass the proxy as a domain name (for instance `proxy.example.com`) instead of providing the IP address.

The `to_socket_addrs` method returns an iterator of `Option<SocketAddr>` (for domain name pointing to multiple IP address). I just use the first one.

I don't know if there is any reason to not support domain name resolution by default on moproxy.