### PR TITLE
build aarch64, rpm packages

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -36,6 +36,12 @@ jobs:
             target: armv7-unknown-linux-gnueabihf
             suffix: linux_armv7_gnueabihf.bin
             toolchain: stable
+            
+          - release_for: Linux-aarch64
+            os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            suffix: linux_aarch64.bin
+            toolchain: stable
 
           # Disabled until corss release a new version
           # https://github.com/cross-rs/cross/issues/1222
@@ -55,6 +61,14 @@ jobs:
       - name: Install musl-tools
         if: contains(matrix.platform.target, 'linux-musl')
         run: sudo apt install musl-tools
+      - name: Install RPM tools
+        if: contains(matrix.platform.target, 'linux-gnu')
+        run: sudo apt-get install rpm
+      - name: Install aarch64 binutils
+        if: matrix.platform.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          sudo apt-get install binutils-aarch64-linux-gnu build-essential crossbuild-essential-arm64 pkg-config libc6-arm64-cross libgcc1-arm64-cross libstdc++6-arm64-cross
+          sudo dpkg --add-architecture arm64
       - name: Build
         uses: houseabsolute/actions-rust-cross@v0
         with:
@@ -63,11 +77,26 @@ jobs:
           toolchain: ${{ matrix.platform.toolchain }}
           args: --release
           strip: yes
-      - name: Packaging for Debian
+      - name: Packaging for Debian - x84_64
         if: matrix.platform.target == 'x86_64-unknown-linux-gnu'
         run: |
           cargo install cargo-deb
           cargo deb --target=${{ matrix.platform.target }} --no-build
+      - name: Packaging for Debian - aarch64
+        if: matrix.platform.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          cargo install cargo-deb
+          cargo deb --target=${{ matrix.platform.target }} --no-build --no-strip
+      - name: Packaging for RPM - x86_64
+        if: matrix.platform.target == 'x86_64-unknown-linux-gnu'
+        run: |
+          cargo install cargo-generate-rpm
+          cargo generate-rpm --target=${{ matrix.platform.target }}
+      - name: Packaging for RPM - aarch64
+        if: matrix.platform.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          cargo install cargo-generate-rpm
+          cargo generate-rpm --target=${{ matrix.platform.target }}
       - name: Packaging binary for Linux
         if: contains(matrix.platform.os, 'ubuntu')
         run: xz -kfS "_${GITHUB_REF#*/v}_${{ matrix.platform.suffix }}.xz" target/${{ matrix.platform.target }}/release/moproxy
@@ -77,7 +106,7 @@ jobs:
       - name: Release
         uses: ncipollo/release-action@v1
         with:
-          artifacts: "*.xz,target/**/*.xz,target/**/*.deb"
+          artifacts: "*.xz,target/**/*.xz,target/**/*.deb,target/**/*.rpm"
           draft: true
           allowUpdates: true
           updateOnlyUnreleased: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,3 +77,13 @@ assets = [
     ["conf/proxy.ini", "etc/moproxy/", "644"],
     ["conf/simple_score.lua", "etc/moproxy/", "644"],
 ]
+
+[package.metadata.generate-rpm]
+assets = [
+    { source = "target/release/moproxy", dest = "/usr/bin/moproxy", mode = "755" },
+    { source = "README.md", dest = "/usr/share/doc/moproxy/README", mode = "644" },
+    { source = "conf/moproxy.service", dest = "/usr/lib/systemd/system/moproxy.service", mode = "644" },
+    { source = "conf/config.env", dest = "/etc/moproxy/config.env", mode = "644" },
+    { source = "conf/proxy.ini", dest = "/etc/moproxy/proxy.ini", mode = "644" },
+    { source = "conf/simple_score.lua", dest = "/etc/moproxy/simple_score.lua", mode = "644" },
+]


### PR DESCRIPTION
This PR adds package builds for the aarch64 architecture. (sometimes called arm64). 
This architecture is getting quite popular, be it apple silicon, raspberry Pi's, and in our case AWS Graviton CPU's.

I also added RPM package builds, (both x86_64 and aarch64 architectures), so this should install on:
- Redhat Enterprise Linux
- CentOS Stream
- AlmaLinux (Personally tested the aarch64 package on Alma 9, my main reason for making this PR)
- Rocky Linux
- Oracle Linux?
- ...

The aarch64 debian package build could be handy for people running raspbian/Ubuntu IoT too.

I had to install some aarch64 dependencies for cross-platform building. 
Not sure if they are all needed, but this made the aarch64 deb package build stop complaining about dynamically linked libs being missing.

You can have a look at the artifacts I built in my fork: https://github.com/vdmkenny/moproxy/releases/tag/v0.5.1-test13