### PR TITLE
Add support for reading passwords from a shell command

### DIFF
--- a/conf/proxy.ini
+++ b/conf/proxy.ini
@@ -15,10 +15,14 @@
 # Attributes for SOCKSv5
 # - socks username, socks password:
 #     Username/password authentication (RFC 1929) for upstream proxy
+# - socks password eval:
+#     Read the password from the stdout of the specified shell command
 #
 # Attributes for HTTP
 # - http username, http password:
 #     HTTP basic access authentication for upstream proxy
+# - http password eval:
+#     Read the HTTP basic password from the stdout of the specified shell command
 #
 # `address` and `protocol` are mandatory, others are optional.
 
@@ -41,6 +45,12 @@ protocol=http
 ; server-3 serves for port 8001 & 8002, while server-2 is only for
 ; port 8001. server-1 accepts connections coming from any ports specified
 ; by CLI argument --port.
+
+[server-4]
+address=127.0.0.1:2004
+protocol=http
+http username=user
+http password eval=pass Proxy
 
 [backup]
 address=127.0.0.1:2002

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -59,7 +59,7 @@ pub struct UserPassAuthCredential {
 }
 
 impl UserPassAuthCredential {
-    pub fn new<T: AsRef<str>>(username: T, password: T) -> Self {
+    pub fn new<T: AsRef<str>, U: AsRef<str>>(username: T, password: U) -> Self {
         Self {
             username: username.as_ref().into(),
             password: password.as_ref().into(),


### PR DESCRIPTION
This PR allows the users to specify a shell command to evaluate instead of hard-coding passwords in the server list config file. This can be used to safely integrate with various command-line password managers such as `pass` or `rbw`.